### PR TITLE
fix ysoserialPath

### DIFF
--- a/server.py
+++ b/server.py
@@ -191,7 +191,7 @@ if __name__ == "__main__":
     if 'config' in data:
         config_data = data['config']
         if 'ysoserialPath' in config_data:
-            ysoserial_path = config_data['javaBinPath']
+            ysoserialPath = config_data['ysoserialPath']
         if 'javaBinPath' in config_data:
             javaBinPath = config_data['javaBinPath']
         if 'fileOutputDir' in config_data:


### PR DESCRIPTION
parameter does not work In the original program line 194
```
ysoserial_path = config_data['javaBinPath']
```
fix it to
```
ysoserialPath = config_data['ysoserialPath']
```